### PR TITLE
Make the config reloadable

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,31 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
+use tokio::sync::{RwLock, RwLockReadGuard};
+
+#[derive(Debug, Clone)]
+pub struct UpdatableConfig {
+    inner: Arc<RwLock<Config>>,
+}
+
+impl UpdatableConfig {
+    pub fn new(config: Config) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(config)),
+        }
+    }
+
+    pub async fn get(&self) -> RwLockReadGuard<'_, Config> {
+        self.inner.read().await
+    }
+
+    pub async fn update(&self, new_config: Config) {
+        let mut config = self.inner.write().await;
+        *config = new_config;
+    }
+}
 
 #[derive(Deserialize, Debug, Clone)]
 pub struct Config {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::collections::BTreeMap;
 use std::sync::Arc;
+use std::time::SystemTime;
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
 use tokio::sync::{RwLock, RwLockReadGuard};
@@ -31,6 +32,9 @@ impl UpdatableConfig {
 pub struct Config {
     pub bind_address: String,
     pub databases: BTreeMap<String, Database>,
+
+    #[serde(default = "SystemTime::now")]
+    pub updated_at: SystemTime,
 }
 impl Config {
     pub async fn from_file(path: &str) -> anyhow::Result<Config> {
@@ -57,6 +61,7 @@ impl Config {
         databases.insert("my_db_alias".into(), db);
 
         Self {
+            updated_at: SystemTime::now(),
             bind_address: "localhost:8432".into(),
             databases,
         }

--- a/src/core.rs
+++ b/src/core.rs
@@ -5,6 +5,7 @@ use futures::future::select;
 use futures::future::Either;
 use net::write_all_with_timeout;
 use std::collections::{BTreeMap, VecDeque};
+use std::time::SystemTime;
 use tokio::io::AsyncReadExt;
 use tokio::net::TcpStream;
 
@@ -24,6 +25,7 @@ pub struct PgConn {
     pub(crate) msgs: VecDeque<ProtoMessage>,
     pub(crate) server_parameters: BTreeMap<String, String>,
     pub(crate) startup_message: Option<StartupMessage>,
+    pub(crate) created_at: SystemTime,
 }
 
 impl PgConn {
@@ -47,6 +49,7 @@ impl PgConn {
             msgs: VecDeque::new(),
             server_parameters: BTreeMap::new(),
             startup_message: None,
+            created_at: SystemTime::now(),
         })
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ pub mod pool;
 pub mod proto;
 
 use clap::Clap;
-use config::Config;
+use config::{Config, UpdatableConfig};
 use pool::PgPooler;
 use std::net::SocketAddr;
 use tokio::net::TcpListener;
@@ -85,6 +85,7 @@ async fn main() -> anyhow::Result<()> {
     let bind_addr = config.bind_address.parse::<SocketAddr>()?;
     log::info!("Listening on: {:?}", bind_addr);
     let listener = TcpListener::bind(bind_addr).await?;
+    let config = UpdatableConfig::new(config);
     let pooler = PgPooler::new(config.clone());
 
     // Shutdown signal

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -139,6 +139,11 @@ impl ManageConnection for PgConnPool {
     }
 
     async fn is_valid(&self, conn: &mut PooledConnection<'_, Self>) -> Result<(), Self::Error> {
+        // First check to see if the configuration has updated since we used this last.
+        if self.config.get().await.updated_at > conn.created_at {
+            anyhow::bail!("The configuration has changed since this connection was created");
+        }
+
         conn.is_valid()?;
         Ok(())
     }


### PR DESCRIPTION
This moves the config to a RwLock which probably isn't great, but acceptable because the only time tusq grabs a write lock is to swap the config.

The pooler is now updated to check for an out of date config on checkout.