### PR TITLE
Support multi-read startup messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ bind_address = "127.0.0.1:8432"
 some_db = { user = "postgres", password = "123456", dbname = "yolo_db", host = "127.0.0.1" }
 ```
 
-You can also specify `port`, and `pool_size` for each database.
+You can also specify `port` and `pool_size` for each database.
 
 You can send a `SIGHUP` to the running tusq process for a live config reload.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ You can send a `SIGHUP` to the running tusq process for a live config reload.
 ### TODO
 
 1. Support SSL.
-2. Smarter startup message parsing.
 3. Better configuration.
 4. Benchmarking.
 5. Canceling queries.

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -1,4 +1,4 @@
 bind_address = "127.0.0.1:8432"
 
 [databases]
-my_db_alias = { user = "testuser", password = "123456", pool_size = 5, dbname = "dispatch_development", host = "127.0.0.1" }
+my_db_alias = { user = "postgres", password = "123456", pool_size = 5, dbname = "test_db", host = "127.0.0.1" }

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -132,6 +132,14 @@ impl ProtoParser {
         }
     }
 
+    #[inline]
+    pub fn msg_size(buffer: &[u8]) -> Option<usize> {
+        if buffer.len() < 4 {
+            return None;
+        }
+        Some(BigEndian::read_i32(&buffer[0..4]) as usize)
+    }
+
     // This will parse a StartupMessage or SSLRequest using one or more buffers.
     // Unlike the `parse` method, this will copy data in that buffer to create
     // a shareable startup message.


### PR DESCRIPTION
This occurs when startup messages exceed the size of the 8kb buffer. I artificially shortened the buffer while working on this, but it always bothered me that this was possible.

This should be followed up with some more tests, but the `TcpStream` needs to be abstracted into `impl AsyncReadExt` first to make mocking network calls easier.