### PR TITLE
Make PgConn generic over AsyncRead + AsyncWrite

### DIFF
--- a/src/pool.rs
+++ b/src/pool.rs
@@ -43,7 +43,7 @@ impl PgConnPool {
 
 #[async_trait]
 impl ManageConnection for PgConnPool {
-    type Connection = PgConn;
+    type Connection = PgConn<TcpStream>;
     type Error = anyhow::Error;
 
     async fn connect(&self) -> Result<Self::Connection, Self::Error> {


### PR DESCRIPTION
I was able to work around `try_read` being a direct impl on `TcpStream` by splitting the impl for `PgConn` between the generic impl and `PgConn<TcpStream>` since the real purpose of the generic impl is to support better testing. With this in place we should be able to (hopefully easily) test flows in the core module.